### PR TITLE
Add additional functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ coper.isRequestPending()
 ```
 ###### Granted permissions check:
 ```
+// Returns true if all permissions granted
 coper.isPermissionsGranted(Manifest.permission.CAMERA, Manifest.permission.ACCESS_FINE_LOCATION) 
 ```
-####### Note: returns true if all permissions granted
 ### Cancelation
 If you cancel job, request will be left until user will submit, but client will not get response.
 ### State recreation

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ coper.request(
     handleDeniedPermission(deniedResult)
 }
 ```
-##### Also thinking to add api like this:
+##### Execute body if all permissions enabled or throw error:
 ```
 coper.withPermissions(Manifest.permission.CAMERA) {
     launchCamera()
@@ -110,14 +110,22 @@ coper.withPermissions(Manifest.permission.CAMERA) {
 ```
 ###### Note:
 If permission will not be granted, then request crash with `PermissionsRequestFailedException`
+##### Additional functionality:
+###### Request pending check:
+```
+coper.isRequestPending()
+```
+###### Granted permissions check:
+```
+coper.isPermissionsGranted(Manifest.permission.CAMERA, Manifest.permission.ACCESS_FINE_LOCATION) 
+```
+####### Note: returns true if all permissions granted
 ### Cancelation
 If you cancel job, request will be left until user will submit, but client will not get response.
 ### State recreation
 Sometimes after application killed (for example temporally killing to preserve memory), the dialog could be still visible, but reference to request will be lost.
 Putting application to background or `onConfigurationChange` will not affect request.
-
 ### License
-
 ```
 MIT License
 

--- a/library/src/main/java/com/vinted/coper/Coper.kt
+++ b/library/src/main/java/com/vinted/coper/Coper.kt
@@ -46,4 +46,6 @@ interface Coper {
         vararg permissions: String,
         onSuccess: suspend (PermissionResult.Granted) -> Unit
     )
+
+    fun isRequestPending(): Boolean
 }

--- a/library/src/main/java/com/vinted/coper/Coper.kt
+++ b/library/src/main/java/com/vinted/coper/Coper.kt
@@ -48,4 +48,6 @@ interface Coper {
     )
 
     fun isRequestPending(): Boolean
+
+    fun isPermissionsGranted(vararg permissions: String): Boolean
 }

--- a/library/src/main/java/com/vinted/coper/Coper.kt
+++ b/library/src/main/java/com/vinted/coper/Coper.kt
@@ -49,5 +49,8 @@ interface Coper {
 
     fun isRequestPending(): Boolean
 
+    /**
+     * @return true if all [permissions] is granted, false if at least one denied.
+     */
     fun isPermissionsGranted(vararg permissions: String): Boolean
 }

--- a/library/src/main/java/com/vinted/coper/CoperFragment.kt
+++ b/library/src/main/java/com/vinted/coper/CoperFragment.kt
@@ -44,6 +44,12 @@ internal class CoperFragment : Fragment() {
         }
     }
 
+    internal fun isPermissionsGranted(permissions: Array<out String>): Boolean {
+        val permissionCheckResult = checkPermissions(permissions)
+        val grantedPermissions = permissionCheckResult.filterGrantedPermissions()
+        return grantedPermissions.isNotEmpty()
+    }
+
     internal fun isRequestPending(): Boolean {
         val permissionRequestState = permissionRequestState
         return permissionRequestState != null && !permissionRequestState.deferred.isCompleted

--- a/library/src/main/java/com/vinted/coper/CoperFragment.kt
+++ b/library/src/main/java/com/vinted/coper/CoperFragment.kt
@@ -43,6 +43,11 @@ internal class CoperFragment : Fragment() {
         }
     }
 
+    internal fun isRequestPending(): Boolean {
+        val permissionRequestState = permissionRequestState
+        return permissionRequestState != null && !permissionRequestState.deferred.isCompleted
+    }
+
     internal suspend fun requestPermission(permissions: Array<out String>): PermissionResult {
         return mutex.withLock {
             val checkPermissionResults = checkPermissions(permissions)

--- a/library/src/main/java/com/vinted/coper/CoperFragment.kt
+++ b/library/src/main/java/com/vinted/coper/CoperFragment.kt
@@ -1,6 +1,7 @@
 package com.vinted.coper
 
 import android.os.Bundle
+import android.util.Log
 import androidx.core.app.ActivityCompat
 import androidx.core.content.PermissionChecker
 import androidx.fragment.app.Fragment
@@ -119,8 +120,14 @@ internal class CoperFragment : Fragment() {
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode != REQUEST_CODE) return
-        if (permissions.isEmpty() && grantResults.isEmpty()) return
+        if (requestCode != REQUEST_CODE) {
+            Log.e(TAG, "Permissions result came with not Coper request code: $requestCode")
+            return
+        }
+        if (permissions.isEmpty() && grantResults.isEmpty()) {
+            Log.i(TAG, "Permissions result and permissions came empty")
+            return
+        }
         onRequestPermissionResult(permissions.toList(), grantResults.toList())
     }
 
@@ -128,8 +135,20 @@ internal class CoperFragment : Fragment() {
         permissions: List<String>,
         permissionsResult: List<Int>
     ) {
-        val permissionRequestState = permissionRequestState ?: return
-        if (permissionRequestState.permissions.toSet() != permissions.toSet()) return
+        val permissionRequestState = permissionRequestState
+        if (permissionRequestState == null) {
+            Log.e(TAG, "Something went wrong with permission request state")
+            return
+        }
+        if (permissionRequestState.permissions.toSet() != permissions.toSet()) {
+            Log.e(
+                TAG,
+                "Permissions (${permissions.joinToString(", ")}) result came not as requested (${permissionRequestState.permissions.joinToString(
+                    ", "
+                )})"
+            )
+            return
+        }
         if (permissionsResult.size != permissions.size) {
             permissionRequestState.deferred.completeExceptionally(
                 PermissionRequestCancelException("Permissions ${permissions.size} is not same size as permissionResult: ${permissionsResult.size}")
@@ -182,6 +201,7 @@ internal class CoperFragment : Fragment() {
     )
 
     companion object {
+        private const val TAG = "CoperFragment"
         private const val REQUEST_CODE = 11111
     }
 }

--- a/library/src/main/java/com/vinted/coper/CoperImpl.kt
+++ b/library/src/main/java/com/vinted/coper/CoperImpl.kt
@@ -33,6 +33,10 @@ internal class CoperImpl(private val fragmentManager: FragmentManager) : Coper {
         getFragment().requestPermission(permissions)
     }
 
+    override fun isRequestPending(): Boolean {
+        return getFragment().isRequestPending()
+    }
+
     @Synchronized
     internal fun getFragment(): CoperFragment {
         val fragment = fragmentManager.findFragmentByTag(FRAGMENT_TAG) as? CoperFragment

--- a/library/src/main/java/com/vinted/coper/CoperImpl.kt
+++ b/library/src/main/java/com/vinted/coper/CoperImpl.kt
@@ -37,6 +37,10 @@ internal class CoperImpl(private val fragmentManager: FragmentManager) : Coper {
         return getFragment().isRequestPending()
     }
 
+    override fun isPermissionsGranted(vararg permissions: String): Boolean {
+        return getFragment().isPermissionsGranted(permissions)
+    }
+
     @Synchronized
     internal fun getFragment(): CoperFragment {
         val fragment = fragmentManager.findFragmentByTag(FRAGMENT_TAG) as? CoperFragment

--- a/library/src/test/java/com/vinted/coper/CoperImplTest.kt
+++ b/library/src/test/java/com/vinted/coper/CoperImplTest.kt
@@ -27,7 +27,6 @@ class CoperImplTest {
     private val shadowActivity = shadowOf(activity)
     private val fixture: CoperImpl = spy(CoperImpl(activity.supportFragmentManager))
 
-
     @Before
     fun setup() = runBlocking {
         whenever(fixture.isTestDispatcher).thenReturn(true)
@@ -629,6 +628,36 @@ class CoperImplTest {
             assertTrue(isPending)
             responseAsync.cancel()
         }
+    }
+
+    @Test
+    @Config(sdk = [21, 23, 27])
+    fun isPermissionsGranted_permissionsNotGranted_returnsFalse() {
+        mockCheckPermissions("not_granted", PermissionChecker.PERMISSION_DENIED)
+
+        val isGranted = fixture.isPermissionsGranted("not_granted")
+
+        assertFalse(isGranted)
+    }
+
+    @Test
+    @Config(sdk = [21, 23, 27])
+    fun isPermissionsGranted_permissionsNotGrantedByOp_returnsFalse() {
+        mockCheckPermissions("not_granted_op", PermissionChecker.PERMISSION_DENIED_APP_OP)
+
+        val isGranted = fixture.isPermissionsGranted("not_granted_op")
+
+        assertFalse(isGranted)
+    }
+
+    @Test
+    @Config(sdk = [21, 23, 27])
+    fun isPermissionsGranted_permissionsGranted_returnsTrue() {
+        mockCheckPermissions("granted", PermissionChecker.PERMISSION_GRANTED)
+
+        val isGranted = fixture.isPermissionsGranted("granted")
+
+        assertTrue(isGranted)
     }
 
     @Test

--- a/library/src/test/java/com/vinted/coper/CoperImplTest.kt
+++ b/library/src/test/java/com/vinted/coper/CoperImplTest.kt
@@ -560,6 +560,29 @@ class CoperImplTest {
         }
     }
 
+    @Test
+    fun isRequestPending_requestNotPending_returnsFalse() {
+        val isPending = fixture.isRequestPending()
+
+        assertFalse(isPending)
+    }
+
+    @Test
+    fun isRequestPending_requestIsPending_returnsTrue() {
+        mockCheckPermissions("test", PermissionChecker.PERMISSION_DENIED)
+        runBlocking {
+            val responseAsync = async {
+                fixture.request("test")
+            }
+            delay(5)
+
+            val isPending = fixture.isRequestPending()
+
+            assertTrue(isPending)
+            responseAsync.cancel()
+        }
+    }
+
     private suspend fun executePermissionRequest(
         permissions: List<String>,
         permissionResult: List<Int>,


### PR DESCRIPTION
- Add two new apis in coper:
  - isRequestPending()
  - isPermissionsGranted(permissions: String)
- Cover functionality on api 21 and 22, there was no runtime permission check, so it needs response right away.
- Add missing tests for result apis
- Add tests for new apis
- Fix stub on request response in tests
- Add logs on not expected results in request