### PR TITLE
Update tooling

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,6 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:${Versions.ANDROID_GRADLE_PLUGIN}")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.KOTLIN}")
-        classpath("com.github.dcendents:android-maven-gradle-plugin:${Versions.ANDROID_MAVEN}")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:${Versions.ANDROID_GRADLE_PLUGIN}")
@@ -13,7 +13,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven(url = "https://jitpack.io")
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -9,7 +9,7 @@ object Versions {
     const val MOCKITO_KOTILN = "3.2.0"
     const val CORE_KTX = "1.2.0"
     const val FRAGMENT_KTX = "1.2.4"
-    const val DETEKT_RUNTIME = "1.8.0"
+    const val DETEKT_RUNTIME = "1.17.1"
     const val LIFECYCLE = "2.2.0"
 
     const val COMPILE_SDK_VERSION = 29

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,20 +1,25 @@
 object Versions {
     const val APP_COMPAT = "1.1.0"
-    const val KOTLIN = "1.4.10"
-    const val COROUTINES = "1.4.2"
-    const val ANDROID_GRADLE_PLUGIN = "4.0.1"
+    const val KOTLIN = "1.5.10"
+    const val COROUTINES = "1.5.0"
+    const val ANDROID_GRADLE_PLUGIN = "4.2.1"
     const val JUNIT = "4.13"
     const val ROBOLECTRIC = "4.3"
-    const val MOCKITO = "3.1.0"
-    const val MOCKITO_KOTILN = "2.2.0"
+    const val MOCKITO = "3.11.2"
+    const val MOCKITO_KOTILN = "3.2.0"
     const val CORE_KTX = "1.2.0"
     const val FRAGMENT_KTX = "1.2.4"
-    const val ANDROID_MAVEN = "2.1"
     const val DETEKT_RUNTIME = "1.8.0"
     const val LIFECYCLE = "2.2.0"
 
     const val COMPILE_SDK_VERSION = 29
     const val MIN_SDK_VERSION = 21
+
+    private const val MAJOR = 0
+    private const val MINOR = 4
+    private const val PATCH = 0
+
+    const val VERSION_NAME: String = "$MAJOR.$MINOR.$PATCH"
 }
 
 object Libs {
@@ -25,7 +30,7 @@ object Libs {
     const val JUNIT = "junit:junit:${Versions.JUNIT}"
     const val ROBOLECTRIC = "org.robolectric:robolectric:${Versions.ROBOLECTRIC}"
     const val MOCKITO = "org.mockito:mockito-core:${Versions.MOCKITO}"
-    const val MOCKITO_KOTLIN = "com.nhaarman.mockitokotlin2:mockito-kotlin:${Versions.MOCKITO_KOTILN}"
+    const val MOCKITO_KOTLIN = "org.mockito.kotlin:mockito-kotlin:${Versions.MOCKITO_KOTILN}"
     const val CORE_KTX = "androidx.core:core-ktx:${Versions.CORE_KTX}"
     const val KOTLIN_TESTS = "org.jetbrains.kotlin:kotlin-test:${Versions.KOTLIN}"
     const val FRAGMENT_KTX = "androidx.fragment:fragment-ktx:${Versions.FRAGMENT_KTX}"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-all.zip

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,9 +1,13 @@
+import Versions.VERSION_NAME
+
 plugins {
     id("com.android.library")
-    id("com.github.dcendents.android-maven")
+    id("maven-publish")
     kotlin("android")
     kotlin("android.extensions")
 }
+
+group = "com.github.vinted"
 
 android {
     compileSdkVersion(Versions.COMPILE_SDK_VERSION)
@@ -15,7 +19,19 @@ android {
     buildTypes {
         kotlinOptions {
             freeCompilerArgs = listOf("-Xopt-in=kotlin.contracts.ExperimentalContracts")
+        }
+    }
+}
 
+afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("release") {
+                groupId = "$group"
+                artifactId = "coper"
+                version = VERSION_NAME
+                from(components["release"])
+            }
         }
     }
 }
@@ -29,7 +45,7 @@ tasks {
 
     val javaDoc by creating(Javadoc::class) {
         isFailOnError = false
-        source = main.java.sourceFiles
+        source = main.java.getSourceFiles()
         classpath += project.files(android.bootClasspath.joinToString(File.pathSeparator))
     }
 

--- a/library/src/test/java/com/vinted/coper/CoperImplTest.kt
+++ b/library/src/test/java/com/vinted/coper/CoperImplTest.kt
@@ -7,7 +7,6 @@ import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import com.nhaarman.mockitokotlin2.*
 import com.vinted.coper.CoperImpl.Companion.FRAGMENT_TAG
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.filterNotNull
@@ -15,7 +14,10 @@ import kotlinx.coroutines.flow.first
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.eq
+import org.mockito.Mockito.*
+import org.mockito.kotlin.anyArray
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.whenever
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf


### PR DESCRIPTION
Kotlin 1.4.10 -> 1.5.10
Kotlin Coroutines  1.4.2 -> 1.5.0
AGP 4.0.1 -> 4.2.1
Mockito 3.1.0 -> 3.11.2
Mockito Kotlin 2.2.0 -> 3.2.0
Gradle 6.3 -> 7.1
Detekt 1.8.0 -> 1.17.1

Also, removed  third party deprecated `com.github.dcendents:android-maven-gradle-plugin` in favour of `maven-publish` plugin which is recommended by Gradle and Android. It also simplifies local library development, no need to add any changes in Gradle build scripts. Just invoke `./gradlew publishToMavenLocal` and once completed - find your artifact under `~/.m2` package.

We can also update our `groupId` in the readme file. Jitpack allows to have organization alias, therefore we could change from:

`com.github.vinted:coper:<version>`

to

`com.vinted:coper:<version>`