### PR TITLE
Update Robolectric 4.3 -> 4.4.1

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -4,7 +4,7 @@ object Versions {
     const val COROUTINES = "1.5.0"
     const val ANDROID_GRADLE_PLUGIN = "4.2.1"
     const val JUNIT = "4.13"
-    const val ROBOLECTRIC = "4.3"
+    const val ROBOLECTRIC = "4.4.1"
     const val MOCKITO = "3.11.2"
     const val MOCKITO_KOTILN = "3.2.0"
     const val CORE_KTX = "1.2.0"


### PR DESCRIPTION
I update Robolectric version because we are having https://github.com/robolectric/robolectric/issues/5456 this issue. Robolectric can't download its own artifacts during running tests.

Release notes:
https://github.com/robolectric/robolectric/releases/tag/robolectric-4.4
- Lots of fixes and improvements.
- Support for Java 11