### PR TITLE
Update Gradle 7.1 -> 7.6.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,7 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-all.zip
+#list: https://services.gradle.org/distributions/
+#curl -L "https://services.gradle.org/distributions/gradle-7.6.2-all.zip.sha256"
+distributionSha256Sum=5861dcc093556fef71cdde8cbae9887be70a8bf40e0f5856b61181ae92dccf33
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-all.zip


### PR DESCRIPTION
- Updated Gradle 7.1 -> 7.6.2
- Added SHA check

Release notes:
https://gradle.org/releases/
- Added Java 17/18/19 support (we are bumping through quite a lot of versions. So multiple Java version support was added)
- Lots of fixes and improvements
- Can't find any breaking changes. But still, we are not updating the major version

