### PR TITLE
Update Kotlin 1.5.10 -> 1.9.0, AGP 4.2.1 -> 7.4.2 and migrate Kotlin synthetic -> ViewBinding

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,8 +1,8 @@
 object Versions {
     const val APP_COMPAT = "1.1.0"
-    const val KOTLIN = "1.5.10"
+    const val KOTLIN = "1.8.0"
     const val COROUTINES = "1.5.0"
-    const val ANDROID_GRADLE_PLUGIN = "4.2.1"
+    const val ANDROID_GRADLE_PLUGIN = "7.4.2"
     const val JUNIT = "4.13"
     const val ROBOLECTRIC = "4.3"
     const val MOCKITO = "3.11.2"
@@ -11,6 +11,7 @@ object Versions {
     const val FRAGMENT_KTX = "1.2.4"
     const val DETEKT_RUNTIME = "1.23.1"
     const val LIFECYCLE = "2.2.0"
+    const val VIEW_BINDING_DELEGATE = "1.5.9"
 
     const val COMPILE_SDK_VERSION = 29
     const val MIN_SDK_VERSION = 21
@@ -36,4 +37,5 @@ object Libs {
     const val FRAGMENT_KTX = "androidx.fragment:fragment-ktx:${Versions.FRAGMENT_KTX}"
     const val MOCKITO_INLINE = "org.mockito:mockito-inline:${Versions.MOCKITO}"
     const val LIFECYCLE = "androidx.lifecycle:lifecycle-common-java8:${Versions.LIFECYCLE}"
+    const val VIEW_BINDING_DELEGATE = "com.github.kirich1409:viewbindingpropertydelegate-noreflection:${Versions.VIEW_BINDING_DELEGATE}"
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -37,5 +37,6 @@ object Libs {
     const val FRAGMENT_KTX = "androidx.fragment:fragment-ktx:${Versions.FRAGMENT_KTX}"
     const val MOCKITO_INLINE = "org.mockito:mockito-inline:${Versions.MOCKITO}"
     const val LIFECYCLE = "androidx.lifecycle:lifecycle-common-java8:${Versions.LIFECYCLE}"
-    const val VIEW_BINDING_DELEGATE = "com.github.kirich1409:viewbindingpropertydelegate-noreflection:${Versions.VIEW_BINDING_DELEGATE}"
+    const val VIEW_BINDING_DELEGATE = "com.github.kirich1409:" +
+            "viewbindingpropertydelegate-noreflection:${Versions.VIEW_BINDING_DELEGATE}"
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -37,6 +37,6 @@ object Libs {
     const val FRAGMENT_KTX = "androidx.fragment:fragment-ktx:${Versions.FRAGMENT_KTX}"
     const val MOCKITO_INLINE = "org.mockito:mockito-inline:${Versions.MOCKITO}"
     const val LIFECYCLE = "androidx.lifecycle:lifecycle-common-java8:${Versions.LIFECYCLE}"
-    const val VIEW_BINDING_DELEGATE = "com.github.kirich1409:" +
-            "viewbindingpropertydelegate-noreflection:${Versions.VIEW_BINDING_DELEGATE}"
+    @Suppress("MaxLineLength")
+    const val VIEW_BINDING_DELEGATE = "com.github.kirich1409:viewbindingpropertydelegate-noreflection:${Versions.VIEW_BINDING_DELEGATE}"
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 object Versions {
     const val APP_COMPAT = "1.1.0"
-    const val KOTLIN = "1.8.0"
+    const val KOTLIN = "1.9.0"
     const val COROUTINES = "1.5.0"
     const val ANDROID_GRADLE_PLUGIN = "7.4.2"
     const val JUNIT = "4.13"

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("com.android.application")
     kotlin("android")
-    kotlin("android.extensions")
 }
 
 android {
@@ -28,6 +27,10 @@ android {
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }
+    buildFeatures {
+        viewBinding = true
+    }
+    namespace = "com.vinted.coper.example"
 }
 
 dependencies {
@@ -37,5 +40,6 @@ dependencies {
     implementation(Libs.CORE_KTX)
     implementation(Libs.KOTLIN_COROUTINES)
     implementation(Libs.FRAGMENT_KTX)
+    implementation(Libs.VIEW_BINDING_DELEGATE)
     testImplementation(Libs.JUNIT)
 }

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.vinted.coper.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
@@ -14,7 +17,8 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/example/src/main/java/com/vinted/coper/example/ExampleSelectFragment.kt
+++ b/example/src/main/java/com/vinted/coper/example/ExampleSelectFragment.kt
@@ -5,9 +5,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import kotlinx.android.synthetic.main.fragment_example_select.*
+import by.kirich1409.viewbindingdelegate.viewBinding
+import com.vinted.coper.example.databinding.FragmentExampleSelectBinding
 
 class ExampleSelectFragment : Fragment() {
+
+    private val viewBinding: FragmentExampleSelectBinding by viewBinding(
+        FragmentExampleSelectBinding::bind
+    )
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -19,12 +24,12 @@ class ExampleSelectFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        example_select_request_viewmodel.setOnClickListener {
+        viewBinding.exampleSelectRequestViewmodel.setOnClickListener {
             (requireActivity() as MainActivity).addFragmentToActivity(
                 PermissionExampleInBusinessSideFragment()
             )
         }
-        example_select_request_fragment.setOnClickListener {
+        viewBinding.exampleSelectRequestFragment.setOnClickListener {
             (requireActivity() as MainActivity).addFragmentToActivity(PermissionExampleInUIFragment())
         }
     }

--- a/example/src/main/java/com/vinted/coper/example/PermissionExampleBusinessSideViewModelFactory.kt
+++ b/example/src/main/java/com/vinted/coper/example/PermissionExampleBusinessSideViewModelFactory.kt
@@ -7,7 +7,7 @@ import com.vinted.coper.Coper
 class PermissionExampleBusinessSideViewModelFactory(
     private val coper: Coper
 ): ViewModelProvider.Factory {
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return if (modelClass.isAssignableFrom(PermissionExampleInBusinessSideViewModel::class.java)) {
             PermissionExampleInBusinessSideViewModel(coper) as T
         } else {

--- a/example/src/main/java/com/vinted/coper/example/PermissionExampleInBusinessSideFragment.kt
+++ b/example/src/main/java/com/vinted/coper/example/PermissionExampleInBusinessSideFragment.kt
@@ -8,11 +8,16 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.vinted.coper.CoperBuilder
 import com.vinted.coper.PermissionResult
-import kotlinx.android.synthetic.main.fragment_permission_example_in_business_side.*
+import com.vinted.coper.example.databinding.FragmentPermissionExampleInBusinessSideBinding
 
 class PermissionExampleInBusinessSideFragment : Fragment() {
+
+    private val viewBinding: FragmentPermissionExampleInBusinessSideBinding by viewBinding(
+        FragmentPermissionExampleInBusinessSideBinding::bind
+    )
 
     private lateinit var viewModel: PermissionExampleInBusinessSideViewModel
 
@@ -45,17 +50,17 @@ class PermissionExampleInBusinessSideFragment : Fragment() {
             onPermissionResult(it)
         })
 
-        permission_example_in_business_request_one_permission.setOnClickListener {
+        viewBinding.permissionExampleInBusinessRequestOnePermission.setOnClickListener {
             viewModel.onOnePermissionClicked(Manifest.permission.ACCESS_FINE_LOCATION)
         }
 
-        permission_example_in_business_request_two_permission_one_request.setOnClickListener {
+        viewBinding.permissionExampleInBusinessRequestTwoPermissionOneRequest.setOnClickListener {
             viewModel.onTwoPermissionsClickedWithOneRequest(
                 permissionOne = Manifest.permission.ACCESS_FINE_LOCATION,
                 permissionTwo = Manifest.permission.CAMERA
             )
         }
-        permission_example_in_business_request_two_permission_two_requests.setOnClickListener {
+        viewBinding.permissionExampleInBusinessRequestTwoPermissionTwoRequests.setOnClickListener {
             viewModel.onTwoPermissionsClickedWithTwoRequests(
                 permissionOne = Manifest.permission.ACCESS_FINE_LOCATION,
                 permissionTwo = Manifest.permission.CAMERA

--- a/example/src/main/java/com/vinted/coper/example/PermissionExampleInUIFragment.kt
+++ b/example/src/main/java/com/vinted/coper/example/PermissionExampleInUIFragment.kt
@@ -8,11 +8,16 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.vinted.coper.CoperBuilder
 import com.vinted.coper.PermissionResult
-import kotlinx.android.synthetic.main.fragment_permission_example_in_ui.*
+import com.vinted.coper.example.databinding.FragmentPermissionExampleInUiBinding
 
 class PermissionExampleInUIFragment : Fragment() {
+
+    private val viewBinding: FragmentPermissionExampleInUiBinding by viewBinding(
+        FragmentPermissionExampleInUiBinding::bind
+    )
 
     private val coper by lazy {
         CoperBuilder()
@@ -30,14 +35,14 @@ class PermissionExampleInUIFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        permission_example_in_ui_request_one_permission.setOnClickListener {
+        viewBinding.permissionExampleInUiRequestOnePermission.setOnClickListener {
             onOnePermissionClicked()
         }
 
-        permission_example_in_ui_request_two_permission_one_request.setOnClickListener {
+        viewBinding.permissionExampleInUiRequestTwoPermissionOneRequest.setOnClickListener {
             onTwoPermissionsClickedWithOneRequest()
         }
-        permission_example_in_ui_request_two_permission_two_requests.setOnClickListener {
+        viewBinding.permissionExampleInUiRequestTwoPermissionTwoRequests.setOnClickListener {
             onTwoPermissionsClickedWithTwoRequests()
         }
     }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     id("com.android.library")
     id("maven-publish")
     kotlin("android")
-    kotlin("android.extensions")
 }
 
 group = "com.github.vinted"
@@ -21,6 +20,10 @@ android {
             freeCompilerArgs = listOf("-Xopt-in=kotlin.contracts.ExperimentalContracts")
         }
     }
+    buildFeatures {
+        viewBinding = true
+    }
+    namespace = "com.vinted.coper"
 }
 
 afterEvaluate {
@@ -66,6 +69,7 @@ dependencies {
     api(Libs.KOTLIN_COROUTINES)
     implementation(Libs.LIFECYCLE)
     implementation(Libs.FRAGMENT_KTX)
+    implementation(Libs.VIEW_BINDING_DELEGATE)
     testImplementation(Libs.MOCKITO_KOTLIN)
     testImplementation(Libs.KOTLIN_TESTS)
     testImplementation(Libs.JUNIT)

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.vinted.coper" />
+<manifest />


### PR DESCRIPTION
That quite a lot of things going on in this PR:
- Kotlin migration (1.5.10 -> 1.8.0) required more up to date version of AGP
- AGP migration (4.2.1 -> 7.4.2) doesn't support Kotlin Android Extensions
- In order to not use Kotlin Android Extensions I had to migrate Kotlin Synthetic -> ViewBinding
- In order to have type-safe ViewBinding, I had to import https://github.com/androidbroadcast/ViewBindingPropertyDelegate library. This library looks like maintained quite well. And it is very similar to what we have in https://github.com/vinted/android/blob/master/app-features/base/src/main/java/com/vinted/extensions/ViewBindingExtensions.kt. I'm still not sure if it is better to create our own library for that case and reuse it in our projects or we could simply just reuse already created library for that

Release notes:
Kotlin:
https://kotlinlang.org/docs/releases.html#release-details
- Lots of improvements and bug fixes
- Introduced a new K2 compiler. But still not stable yet

AGP:
https://developer.android.com/build/releases/gradle-plugin
AGP doesn't have such old release notes, but breaking changes to note:
- Kotlin Android extensions are not supported anymore
- Needs migration to Kotlin synthetic -> ViewBinding
- Needs migration to Parcelable -> kotlin-parcelize