### PR TITLE
Migrate runBlocking -> runTest

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -28,6 +28,8 @@ object Libs {
     const val APP_COMPAT = "androidx.appcompat:appcompat:${Versions.APP_COMPAT}"
     const val KOTLIN_COROUTINES =
         "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.COROUTINES}"
+    const val KOTLIN_COROUTINES_TEST =
+        "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.COROUTINES}"
     const val JUNIT = "junit:junit:${Versions.JUNIT}"
     const val ROBOLECTRIC = "org.robolectric:robolectric:${Versions.ROBOLECTRIC}"
     const val MOCKITO = "org.mockito:mockito-core:${Versions.MOCKITO}"

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -76,4 +76,5 @@ dependencies {
     testImplementation(Libs.MOCKITO)
     testImplementation(Libs.ROBOLECTRIC)
     testImplementation(Libs.MOCKITO_INLINE)
+    testImplementation(Libs.KOTLIN_COROUTINES_TEST)
 }


### PR DESCRIPTION
There is an issue with using `runBlocking {}` in tests. If you have an endless Coroutine in tests, tests get stuck and run forever. Coroutines have a `runTest` method for running coroutine tests. It has 10s timeout by default which prevent tests from being stuck and doesn't run CI forever

P.S. Change is quite small. But `runTest {}` should be returned in test methods. So that changes the indentation of the code and makes it look horrible in Git