### PR TITLE
Bump Compile SDK 29 -> 33

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -13,7 +13,7 @@ object Versions {
     const val LIFECYCLE = "2.2.0"
     const val VIEW_BINDING_DELEGATE = "1.5.9"
 
-    const val COMPILE_SDK_VERSION = 29
+    const val COMPILE_SDK_VERSION = 33
     const val MIN_SDK_VERSION = 21
 
     private const val MAJOR = 0

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion(Versions.COMPILE_SDK_VERSION)
+    compileSdk = Versions.COMPILE_SDK_VERSION
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
@@ -16,7 +16,7 @@ android {
 
     defaultConfig {
         applicationId = "com.vinted.coper.example"
-        minSdkVersion(Versions.MIN_SDK_VERSION)
+        minSdk = Versions.MIN_SDK_VERSION
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -9,10 +9,10 @@ plugins {
 group = "com.github.vinted"
 
 android {
-    compileSdkVersion(Versions.COMPILE_SDK_VERSION)
+    compileSdk = Versions.COMPILE_SDK_VERSION
 
     defaultConfig {
-        minSdkVersion(Versions.MIN_SDK_VERSION)
+        minSdk = Versions.MIN_SDK_VERSION
     }
 
     buildTypes {


### PR DESCRIPTION
Bumping Compile SDK to 29 -> 33. Because some 3rd party https://github.com/vinted/coper/pull/21 library versions require that. Also, it is healthy to update this version.
Also migrated deprecated `compileSdkVersion` -> `compileSdk` and `minSdkVersion` -> `minSdk`

Everything works as expected. I can't find any changes that affect this library