### PR TITLE
Override JitPack default Java 8 -> Java 11

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
https://jitpack.io/com/github/vinted/coper/0.6/build.log
We have updated the AGP version (https://github.com/vinted/coper/pull/15)
And this AGP version requires Java 11 as a minimum version
But JitPack builds with Java 8 by default (https://jitpack.io/docs/BUILDING/#java-version)
So I added a JitPack config to use Java 11