### PR TITLE
Support library consumers with lower Kotlin version

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -18,6 +18,8 @@ android {
     buildTypes {
         kotlinOptions {
             freeCompilerArgs = listOf("-Xopt-in=kotlin.contracts.ExperimentalContracts")
+            apiVersion = "1.5"
+            languageVersion = "1.5"
         }
     }
     buildFeatures {


### PR DESCRIPTION
<img width="1617" alt="Screenshot 2023-08-23 at 09 34 42" src="https://github.com/vinted/coper/assets/26062704/881d0bb9-ca0e-4965-bfa8-39be1d8b22cc">

After the Kotlin version update, we started to get errors from the consumers of this library which has a lower version of Kotlin ☝️ 
As I read right here: https://proandroiddev.com/kotlin-library-development-for-android-java-hints-29365017516d
We can support lower versions of Kotlin even when we use the latest Kotlin version in our library.

<img width="628" alt="Screenshot 2023-08-23 at 09 38 54" src="https://github.com/vinted/coper/assets/26062704/d212a4c2-156d-44c2-9843-61462cf79f41">

I decided to use "1.5" because it is the lowest and still not deprecated versions