### PR TITLE
Downgrade Kotlin version 1.9.0 -> 1.8.22

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 object Versions {
     const val APP_COMPAT = "1.1.0"
-    const val KOTLIN = "1.9.0"
+    const val KOTLIN = "1.8.22"
     const val COROUTINES = "1.7.3"
     const val ANDROID_GRADLE_PLUGIN = "7.4.2"
     const val JUNIT = "4.13.2"

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -18,8 +18,6 @@ android {
     buildTypes {
         kotlinOptions {
             freeCompilerArgs = listOf("-Xopt-in=kotlin.contracts.ExperimentalContracts")
-            apiVersion = "1.5"
-            languageVersion = "1.5"
         }
     }
     buildFeatures {


### PR DESCRIPTION
<img width="1617" alt="Screenshot 2023-08-23 at 09 34 42" src="https://github.com/vinted/coper/assets/26062704/7ee10157-81f1-4f01-8918-9ec6545b8740">

In library consumers, we get an error if the consumer has a lower version of Kotlin in their project (1.8.22 in this case). So trying to downgrade the Kotlin version in order to support consumers with a lower Kotlin version