### PR TITLE
Remove unnecessary PERMISSION_DENIED_APP_OP test

### DIFF
--- a/library/src/test/java/com/vinted/coper/CoperImplTest.kt
+++ b/library/src/test/java/com/vinted/coper/CoperImplTest.kt
@@ -668,16 +668,6 @@ class CoperImplTest {
 
     @Test
     @Config(sdk = [23, 27])
-    fun isPermissionsGranted_permissionsNotGrantedByOp_returnsFalse() = runTest {
-        mockCheckPermissions("not_granted_op", PermissionChecker.PERMISSION_DENIED_APP_OP)
-
-        val isGranted = fixture.isPermissionsGrantedSafe("not_granted_op")
-
-        assertFalse(isGranted)
-    }
-
-    @Test
-    @Config(sdk = [23, 27])
     fun isPermissionsGranted_permissionsGranted_returnsTrue() = runTest {
         mockCheckPermissions("granted", PermissionChecker.PERMISSION_GRANTED)
 


### PR DESCRIPTION
Related to: https://github.com/vinted/coper/pull/38
I missed removing one test while bumping min SDK version to 23 because it became irrelevant after min SDK bump