### PR TITLE
Upgrade `Robolectric` 4.3 -> 4.10.3

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -4,7 +4,7 @@ object Versions {
     const val COROUTINES = "1.7.3"
     const val ANDROID_GRADLE_PLUGIN = "7.4.2"
     const val JUNIT = "4.13.2"
-    const val ROBOLECTRIC = "4.3"
+    const val ROBOLECTRIC = "4.10.3"
     const val MOCKITO = "4.11.0"
     const val MOCKITO_KOTLIN = "4.1.0"
     const val CORE_KTX = "1.6.0"

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -11,6 +11,15 @@ group = "com.github.vinted"
 android {
     compileSdk = Versions.COMPILE_SDK_VERSION
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
     defaultConfig {
         minSdk = Versions.MIN_SDK_VERSION
     }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -11,15 +11,6 @@ group = "com.github.vinted"
 android {
     compileSdk = Versions.COMPILE_SDK_VERSION
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = "11"
-    }
-
     defaultConfig {
         minSdk = Versions.MIN_SDK_VERSION
     }

--- a/library/src/test/java/com/vinted/coper/CoperImplTest.kt
+++ b/library/src/test/java/com/vinted/coper/CoperImplTest.kt
@@ -430,11 +430,7 @@ class CoperImplTest {
         val crashPermission = "crash"
         mockCheckPermissions(crashPermission, PackageManager.PERMISSION_DENIED)
 
-
-        executePermissionRequest(
-            permissionsToRequest = emptyList(),
-            permissionResult = listOf(PermissionChecker.PERMISSION_GRANTED)
-        )
+        fixture.request(*emptyList<String>().toTypedArray())
     }
 
     @Test(expected = IllegalStateException::class)

--- a/library/src/test/java/com/vinted/coper/CoperImplTest.kt
+++ b/library/src/test/java/com/vinted/coper/CoperImplTest.kt
@@ -744,11 +744,35 @@ class CoperImplTest {
     fun request_requestCodeIsNotOfCoperFragment_throwException() = runTest {
         val requestedPermission = "requested_permission"
 
-        executePermissionRequest(
-            permissionsToRequest = listOf(requestedPermission),
-            permissionResult = listOf(PermissionChecker.PERMISSION_DENIED),
-            requestCode = 0
-        )
+        val coperFragment = fixture.getFragmentSafely()
+
+        whenever(
+            coperFragment.requestPermissions(
+                listOf(requestedPermission).toTypedArray(),
+                0,
+            )
+        ).then {
+            coperFragment.onRequestPermissionResult(
+                permissions = listOf(requestedPermission),
+                permissionsResult = listOf(PermissionChecker.PERMISSION_DENIED),
+                requestCode = 0,
+            )
+        }
+
+        whenever(
+            coperFragment.requestPermissions(
+                listOf(requestedPermission).toTypedArray(),
+                CoperFragment.REQUEST_CODE
+            )
+        ).then {
+            coperFragment.onRequestPermissionResult(
+                permissions = listOf(requestedPermission),
+                permissionsResult = listOf(PermissionChecker.PERMISSION_DENIED),
+                requestCode = 0,
+            )
+        }
+
+        fixture.request(*listOf(requestedPermission).toTypedArray())
     }
 
     private suspend fun executePermissionRequest(

--- a/library/src/test/java/com/vinted/coper/CoperImplTest.kt
+++ b/library/src/test/java/com/vinted/coper/CoperImplTest.kt
@@ -514,19 +514,6 @@ class CoperImplTest {
     fun request_permissionResultCameWithDifferentPermissions_jobIsNotCompleted() = runTest {
         val permission = "permission"
         mockCheckPermissions(permission, PackageManager.PERMISSION_DENIED)
-        val fragment = fixture.getFragmentSafely()
-        whenever(
-            fragment.requestPermissions(
-                eq(listOf(permission).toTypedArray()),
-                anyOrNull()
-            )
-        ).then {
-            fragment.onRequestPermissionResult(
-                permissions = listOf("test"),
-                permissionsResult = listOf(PermissionChecker.PERMISSION_GRANTED),
-                requestCode = CoperFragment.REQUEST_CODE
-            )
-        }
 
         val responseAsync = async {
             fixture.request(permission)

--- a/library/src/test/java/com/vinted/coper/CoperImplTest.kt
+++ b/library/src/test/java/com/vinted/coper/CoperImplTest.kt
@@ -543,17 +543,18 @@ class CoperImplTest {
     fun request_twoIdenticalRequest_twoRequestCompleted() = runTest {
         val permission = "sameRequest"
         mockCheckPermissions(permission, PermissionChecker.PERMISSION_DENIED)
+
+        stubRequestPermission(
+            coperFragment = fixture.getFragmentSafely(),
+            permissions = listOf(permission),
+            permissionResults = listOf(PermissionChecker.PERMISSION_GRANTED),
+        )
+
         val responseAsync1 = async {
-            executePermissionRequest(
-                permissionsToRequest = listOf(permission),
-                permissionResult = listOf(PermissionChecker.PERMISSION_GRANTED)
-            )
+            fixture.request(*listOf(permission).toTypedArray())
         }
         val responseAsync2 = async {
-            executePermissionRequest(
-                permissionsToRequest = listOf(permission),
-                permissionResult = listOf(PermissionChecker.PERMISSION_GRANTED)
-            )
+            fixture.request(*listOf(permission).toTypedArray())
         }
         val result2 = responseAsync2.await()
         val result1 = responseAsync1.await()

--- a/library/src/test/java/com/vinted/coper/CoperImplTest.kt
+++ b/library/src/test/java/com/vinted/coper/CoperImplTest.kt
@@ -599,8 +599,8 @@ class CoperImplTest {
             val coperFragment = fixture.getFragmentSafely()
             whenever(
                 coperFragment.requestPermissions(
-                    eq(arrayOf(firstPermission, secondPermission)),
-                    anyOrNull()
+                    arrayOf(firstPermission, secondPermission),
+                    CoperFragment.REQUEST_CODE
                 )
             ).then {
                 coperFragment.onRequestPermissionResult(

--- a/library/src/test/java/com/vinted/coper/CoperImplTest.kt
+++ b/library/src/test/java/com/vinted/coper/CoperImplTest.kt
@@ -813,8 +813,8 @@ class CoperImplTest {
     ) {
         whenever(
             coperFragment.requestPermissions(
-                eq(permissions.toTypedArray()),
-                anyOrNull()
+                permissions.toTypedArray(),
+                requestCode,
             )
         ).then {
             coperFragment.onRequestPermissionResult(


### PR DESCRIPTION
Upgraded Robolectric to newest version. Mainly adjusted usage of argument matches and timing when stubbing.