### PR TITLE
Commit `CoperFragment` only before `onStateSaved`

### DIFF
--- a/library/src/main/java/com/vinted/coper/CoperImpl.kt
+++ b/library/src/main/java/com/vinted/coper/CoperImpl.kt
@@ -106,13 +106,17 @@ internal class CoperImpl(
         fragmentManager: FragmentManager
     ): CoperFragment {
         return suspendCancellableCoroutine { continuation ->
-            fragmentManager.beginTransaction()
-                .add(this, FRAGMENT_TAG)
-                .runOnCommit {
-                    continuation.resume(this)
-                }
-                .commit()
-            _latestCommittedFragmentFlow.value = this
+            if (!fragmentManager.isStateSaved) {
+                fragmentManager.beginTransaction()
+                    .add(this, FRAGMENT_TAG)
+                    .runOnCommit {
+                        continuation.resume(this)
+                    }
+                    .commit()
+                _latestCommittedFragmentFlow.value = this
+            } else {
+                continuation.cancel()
+            }
         }
     }
 


### PR DESCRIPTION
When try to commit `CoperFragment`, there is an chance fragment state being already saved which result to `IllegalStateException`. `fragmentManager.isStateSaved` is checked before fragment transition 